### PR TITLE
UPDATE [sc-757] - using npx and cache isn't compatible

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,22 +1,19 @@
-name: pre-release
-on:
-  push:
-    branches:
-      - develop
+name: deploy-pages
+on: workflow_dispatch
 
 jobs:
-  pre-release:
+  deploy-pages:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.2 # matching Elctron's version of node
+          node-version: 16.13.2
 
       - name: Get Cache Directory Path
         id: yarn-cache-dir-path
@@ -30,20 +27,26 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      
+      - name: Cache Modules
+        uses: actions/cache@v3
+        id: yarn-cache-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-modules-
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Build Executables
+      - name: Build Pages
+        run: yarn run build:downloads
+
+      - name: Publish Github Page
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: apps/app-downloads/dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn run package:tool:course
-
-      - uses: marvinpinto/action-automatic-releases@latest
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: latest
-          prerelease: true
-          title: Development Build
-          files: |
-            ./apps/course-authoring/release/build/Scrowl-1.0.0.dmg


### PR DESCRIPTION
- running `npx electron-builder build` produces this error `npm ERR! could not determine executable to run`
- moved the action to deploy the github pages into its own worklow as it is not needed to be deployed with every update
