### PR TITLE
[sc-788] - Chore/Structure workspace

### DIFF
--- a/apps/course-authoring/src/renderer/components/app/styles/_forms.scss
+++ b/apps/course-authoring/src/renderer/components/app/styles/_forms.scss
@@ -1,0 +1,4 @@
+.field {
+  display: flex;
+  flex-direction: column;
+}

--- a/apps/course-authoring/src/renderer/components/app/styles/styles.module.scss
+++ b/apps/course-authoring/src/renderer/components/app/styles/styles.module.scss
@@ -1,4 +1,5 @@
 @import './reset';
+@import './forms';
 
 :global .drag {
   -webkit-app-region: drag;

--- a/apps/course-authoring/src/renderer/components/navigationbar/index.tsx
+++ b/apps/course-authoring/src/renderer/components/navigationbar/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import style from './styles.module.scss';
 import { Link, useMatch, useResolvedPath } from 'react-router-dom';
-import { PageNav, PageNavItem } from '../../pages/index.types';
+import { PageNavItem } from '../../pages/index.types';
+import { Default as Btn } from '@owlui/button';
+import { NavigationBarProps } from './index.types';
 
 const NavigationItem = ({ page }: { page: PageNavItem }) => {
   const resolved = useResolvedPath(page.link);
@@ -18,13 +20,18 @@ const NavigationItem = ({ page }: { page: PageNavItem }) => {
   );
 };
 
-export const NavigationBar = ({ pages }: { pages: PageNav }) => {
+export const NavigationBar = ({ pages, exportPackage }: NavigationBarProps) => {
   return (
-    <ul className={style.navigationBar}>
-      {pages.map((page: PageNavItem, index: number) => {
-        return <NavigationItem key={index} page={page} />;
-      })}
-    </ul>
+    <div className={style.topContainer}>
+      <ul className={style.navigationBar}>
+        {pages.map((page: PageNavItem, index: number) => {
+          return <NavigationItem key={index} page={page} />;
+        })}
+      </ul>
+      <Btn size="Sm" onClick={exportPackage}>
+        Export
+      </Btn>
+    </div>
   );
 };
 

--- a/apps/course-authoring/src/renderer/components/navigationbar/index.types.ts
+++ b/apps/course-authoring/src/renderer/components/navigationbar/index.types.ts
@@ -1,0 +1,6 @@
+import { PageNav } from '../../pages/index.types';
+
+export interface NavigationBarProps {
+  pages: PageNav;
+  exportPackage: () => void;
+}

--- a/apps/course-authoring/src/renderer/components/navigationbar/styles.module.scss
+++ b/apps/course-authoring/src/renderer/components/navigationbar/styles.module.scss
@@ -1,5 +1,10 @@
 @use '~@owlui/theme/src' as theme;
 
+.top-container {
+  display: flex;
+  justify-content: space-between;
+}
+
 .navigation-bar {
   display: flex;
 }

--- a/apps/course-authoring/src/renderer/pages/editor/course.types.ts
+++ b/apps/course-authoring/src/renderer/pages/editor/course.types.ts
@@ -1,0 +1,44 @@
+export interface Course extends CourseData {
+  modules?: Module[] | string;
+}
+
+export interface CourseData {
+  id: string;
+  createdAt: string;
+  modifiedAt: string;
+  name: string;
+  description?: string;
+  authors?: string;
+  theme?: string;
+}
+
+export interface Module {
+  id: number;
+  name: string;
+  pages: Page[];
+}
+
+export interface Page {
+  id: number;
+  name: string;
+  type: 'lesson' | 'quiz';
+  stages: Stage[];
+}
+
+export interface Stage {
+  id: number;
+  name: string;
+  blocks: Block[];
+}
+
+export interface Block {
+  id: number;
+  typeId: 'p' | 'h1' | 'button';
+  element: Element;
+}
+
+export interface Element {
+  name: string;
+  content?: string;
+  classNames?: string;
+}

--- a/apps/course-authoring/src/renderer/pages/editor/index.tsx
+++ b/apps/course-authoring/src/renderer/pages/editor/index.tsx
@@ -8,6 +8,16 @@ import { PageProps } from '../index.types';
 export const PageRoute = '/editor/*';
 export const PageName = 'Course Editor';
 
+const exportPackage = () => {
+  window.electronAPI.ipcRenderer
+    .invoke('package-course', {
+      courseName: 'Test Course',
+    })
+    .then((msg: string) => {
+      console.log(`packaged ${msg}`);
+    });
+};
+
 export const PageElement = ({ handleTitleChange }: PageProps) => {
   const pageRoutes = PageNavItems.map(page => {
     return { label: page.label, link: page.link };
@@ -20,7 +30,7 @@ export const PageElement = ({ handleTitleChange }: PageProps) => {
 
   return (
     <div className={style.editor}>
-      <NavigationBar pages={PageNavItems} />
+      <NavigationBar pages={PageNavItems} exportPackage={exportPackage} />
       <Routes>
         {PageChildren.map((page, index) => {
           return (

--- a/apps/course-authoring/src/renderer/pages/editor/structure/index.tsx
+++ b/apps/course-authoring/src/renderer/pages/editor/structure/index.tsx
@@ -5,10 +5,25 @@ import { Default as Nav } from '@owlui/navigationdrawer';
 export const PageRoute = '/structure';
 export const PageName = 'Structure';
 
+const SidebarContent = (
+  <>
+    <div>
+      <h3>Project Settings</h3>
+      <div className="field">
+        <label className="field__label" htmlFor="project-name">
+          Project Name<i aria-hidden="true">*</i>
+        </label>
+        <input className="field__input" id="project-name" type="text" />
+      </div>
+    </div>
+    <div className={style.navDivider} />
+  </>
+);
+
 export const Element = () => {
   return (
     <section className={style.structure}>
-      <Nav />
+      <Nav header={SidebarContent} />
       <main></main>
     </section>
   );

--- a/apps/course-authoring/src/renderer/pages/editor/structure/index.tsx
+++ b/apps/course-authoring/src/renderer/pages/editor/structure/index.tsx
@@ -1,26 +1,89 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as style from './styles.module.scss';
 import { Default as Nav } from '@owlui/navigationdrawer';
+import { Default as Btn } from '@owlui/button';
+import { CourseData } from '../course.types';
+import { CourseTemplate } from '../templates/course';
 
 export const PageRoute = '/structure';
 export const PageName = 'Structure';
 
-const SidebarContent = (
-  <>
-    <div>
-      <h3>Project Settings</h3>
-      <div className="field">
-        <label className="field__label" htmlFor="project-name">
-          Project Name<i aria-hidden="true">*</i>
-        </label>
-        <input className="field__input" id="project-name" type="text" />
-      </div>
-    </div>
-    <div className={style.navDivider} />
-  </>
-);
-
 export const PageElement = () => {
+  const [courseData, setCourseData] =
+    React.useState<CourseData>(CourseTemplate);
+
+  const handleChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => {
+    const newData = { ...courseData };
+
+    newData[e.target.name as keyof typeof courseData] = e.target.value;
+
+    setCourseData(newData);
+  };
+
+  const SidebarContent = (
+    <>
+      <div>
+        <h3>Project Settings</h3>
+        <div className="field">
+          <label className="field__label" htmlFor="project-name">
+            Project Name<i aria-hidden="true">*</i>
+          </label>
+          <input
+            className="field__input"
+            name="name"
+            id="project-name"
+            value={courseData['name']}
+            onChange={handleChange}
+          />
+        </div>
+        <div className="field">
+          <label className="field__label" htmlFor="project-description">
+            Project Description<i aria-hidden="true">*</i>
+          </label>
+          <textarea
+            className="field__input"
+            name="description"
+            id="project-description"
+            onChange={handleChange}
+            value={courseData['description']}
+          />
+        </div>
+        <div className="field">
+          <label className="field__label" htmlFor="project-authors">
+            Authors<i aria-hidden="true">*</i>
+          </label>
+          <textarea
+            className="field__input"
+            name="authors"
+            id="project-authors"
+            onChange={handleChange}
+            value={courseData['authors']}
+          />
+        </div>
+        <div className="nav__divider" />
+        <div className="field">
+          <label className="field__label" htmlFor="project-theme">
+            Style Theme<i aria-hidden="true">*</i>
+          </label>
+          <select
+            className="field__input"
+            name="theme"
+            id="project-theme"
+            onChange={handleChange}
+            value={courseData['theme']}
+          >
+            <option value="default">Default</option>
+            <option value="dark">Dark</option>
+          </select>
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <section className={style.structure}>
       <Nav header={SidebarContent} />

--- a/apps/course-authoring/src/renderer/pages/editor/templates/course.tsx
+++ b/apps/course-authoring/src/renderer/pages/editor/templates/course.tsx
@@ -1,0 +1,13 @@
+import { CourseData } from '../course.types';
+
+export const CourseTemplate: CourseData = {
+  id: '',
+  createdAt: '',
+  modifiedAt: '',
+  name: '',
+  description: '',
+  authors: '',
+  theme: '',
+};
+
+export default { CourseTemplate };

--- a/apps/course-authoring/src/renderer/pages/home/index.tsx
+++ b/apps/course-authoring/src/renderer/pages/home/index.tsx
@@ -11,16 +11,6 @@ import { CardGrid } from '../../components/cardgrid';
 export const PageRoute = '/';
 export const PageName = 'Home';
 
-const exportPackage = () => {
-  window.electronAPI.ipcRenderer
-    .invoke('package-course', {
-      courseName: 'Test Course',
-    })
-    .then((msg: string) => {
-      console.log(`packaged ${msg}`);
-    });
-};
-
 const Header = (
   <>
     <div>
@@ -36,11 +26,6 @@ const Header = (
       <div>
         <Btn size="Sm" appearance="Link">
           Open
-        </Btn>
-      </div>
-      <div>
-        <Btn size="Sm" onClick={exportPackage}>
-          Export
         </Btn>
       </div>
     </div>


### PR DESCRIPTION
### Short summary
- Populate the left sidebar of the Structure page according to the image attached to [[sc-277]](https://app.shortcut.com/osgca/story/277/course-information).
- No data will be persisted to the database yet, it only updates the component state and this data will be used to update the IndexedDB.
- The `fields` will be replaced by proper OwlUI components once we get them updated/created.
- Course typing was created based on the architecture entity Notion doc, it might be updated along the way. 

---

### Test steps
1. Run `yarn start:tool:course` 
2. Use the `Create New` button from the `New Blank Document` card to go to the Structure page
3. Make sure the items added to the left sidebar match the screenshot attached to [[sc-277]](https://app.shortcut.com/osgca/story/277/course-information)